### PR TITLE
feat: remove new sample and sample checklist from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-### Type of change (place an x in the [ ] that applies)
+### Type of change <!-- place an x in the [ ] that applies -->
 
-- [ ] New sample
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
@@ -11,8 +10,7 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 If you are introducing a new sample app in this pull request, please also include a detailed description of the application’s purpose and functionality.
 
-### Requirements (place an x in each [ ] that applies)
+### Requirements <!-- place an x in each [ ] that applies -->
 
-- [ ] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
 - [ ] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
 - [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)


### PR DESCRIPTION
### Type of change

- [x] New feature

### Summary

This PR hides "instruction" text as comments and removes the following checklist items:

- "New sample"
- "I’ve checked my submission against the Samples Checklist to ensure it complies with all standards"

### Notes

I am unsure if we should reference something elsewhere for the samples checklist standards, but I am open to adding that now or in later updates of course.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
